### PR TITLE
Client identity

### DIFF
--- a/draft-ietf-dance-architecture.md
+++ b/draft-ietf-dance-architecture.md
@@ -273,13 +273,14 @@ which forwarded the information to the application.
 ### Domain Users
 
 The allocation of user identities is the prerogative of a domain, in line with the nesting suggested in URI notation.
+Domains may even choose to assign domain user identities to services, possibly with easily recognised identities like +mail+archive@domain.name.
 Domains who publish TLSA records for a CA under a _user name underneath their domain allow the validation of user identities as mentioned in a certificate as TLS client or peer identities.
 This mechanism is not restricted to domain-internal users, but can be used to validate users under any domain.
 
-Since ENUM maps telephone numbers to DNS names, it is possible to employ these same mechanisms for telephone number users.
-Any DANCEr may however define alternate derivation procedure to obtain the DNS name for a phone number from specialised PKIX or LDAP attributes such as telephoneNumber, telexNumber, homePhone, mobile and pager.
+Since ENUM maps telephone numbers to DNS owner names, it is possible to employ these same mechanisms for telephone number users.
+Any DANCEr may however define alternate derivation procedures to obtain the DNS owner name for a phone number from specialised PKIX or LDAP attributes such as telephoneNumber, telexNumber, homePhone, mobile and pager.
 
-There is no reason why other uses, such as store-and-forward with S/MIME, could not benefit from this form of authentication, as long as they remain mindful that anything in the certificate is the prerogative of the domain publishing the TLSA record, and the only reliable identity statements are for resources underneath the domain -- notably, the assignment of uid names.
+There is no reason why other uses, such as store-and-forward with S/MIME, could not benefit from this DNS-based PKI, as long as they remain mindful that anything in the certificate is the prerogative of the domain publishing the TLSA record, and the only reliable identity statements are for resources underneath the domain -- notably, the assignment of uid names.
 
 ### SIP and WebRTC inter-domain privacy
 

--- a/draft-ietf-dance-architecture.md
+++ b/draft-ietf-dance-architecture.md
@@ -223,12 +223,19 @@ This allows the web application to reject clients with identifiers which are not
 No need to manage an allow-list in the load balancer.
 - This can be implemented with no changes to the TLS handshake.
 
-#### Example 3: TLS user authentication for SMTP submission
+#### Example 3: TLS user authentication for an LDAP query
 
-- The mail user agent initiates a TLS connection the the server, conveying the user's domain via the DANE Client Identity extension.
+- The LDAP client initiates a TLS connection the the server, conveying the user's domain via the DANE Client Identity extension.
 - If the dane_clientid is allowed and begins with a _user label, the TLS server then performs a DNS lookup for TLSA records holding the user's CA, and includes them when requesting a client certificate.
-- If the client's certificate is signed by a CA found in the TLSA records and the certificate's dNSName matches the dane_clientid then the client identity is authenticated to consist of the uid in the certificate, an "@" symbold and the UTF-8 representation of the certificate's dNSName except for its "_user." prefix.
-- The SMTP submission uses SASL EXTERNAL to obtain the authenticated user identity in userid@domain.name form and, if so desired, request it be changed to an authorization identity.
+- If the client's certificate is signed by a CA found in the TLSA records and the certificate's dNSName prefixed with a _user label matches the dane_clientid then the client identity is authenticated to consist of the lowercase uid in the certificate, an "@" symbol and the lowercase UTF-8 representation of the certificate's dNSName (which lacks the "_user." prefix).
+- The LDAP server responds to SASL EXTERNAL authentication by obtaining the authenticated user identity in userid@domain.name form and, if so requested, attempts to change to an authorization identity.
+
+This pattern has the following advantages:
+
+- SASL authentication under TLS encryption is common to many protocols, including new ones.
+- This LDAP example demonstrates the potential of authentication with realm crossover support as a precursor to fine access control to possibly sensitive data.
+- User identities cannot be iterated in DNS; TLS 1.3 conceals the client certificate; TLS in general conceals the user's choice of authorization identity during SASL EXTERNAL.
+- This can be implemented with no changes to the TLS handshake.
 
 ### IoT: Device to cloud
 
@@ -265,7 +272,7 @@ which forwarded the information to the application.
 
 ### Domain Users
 
-The allocation of user identities are the prerogative of a domain, in line with the nesting suggested in URI notation.
+The allocation of user identities is the prerogative of a domain, in line with the nesting suggested in URI notation.
 Domains who publish TLSA records for a CA under a _user name underneath their domain allow the validation of user identities as mentioned in a certificate as TLS client or peer identities.
 This mechanism is not restricted to domain-internal users, but can be used to validate users under any domain.
 


### PR DESCRIPTION
These changes allow what we have in mind for user identification with X.509 certificates.  Even domain services could be named and included in the scheme.

There is a `_user` label that distinguishes this usage pattern from `_device` naming.  The TLSA record is supposed to be a CA, so the user identity is not published in DNS.

An example is given for an LDAP client with access rights based on the domain user identity &mdash; which may be from a local or remote domain.  (Realm Crossover.)